### PR TITLE
Implement closing of the 'add payee' modal

### DIFF
--- a/screens/expenses.screen.js
+++ b/screens/expenses.screen.js
@@ -36,9 +36,7 @@ export class ExpensesScreen extends React.Component {
         animationType="slide"
         transparent={false}
         visible={this.state.showModal}
-        onRequestClose={() => {
-          Alert.alert('Modal has been closed.');
-                  }}>
+        onRequestClose={() => this.setState({showModal: false})}>
         <View style={{marginTop: 22}}>
           <View>
           <Text style={styles.addNewPayee}>


### PR DESCRIPTION
When the hardware back button is pressed on the 'add payee' modal, close the modal instead of showing an error.